### PR TITLE
Feature/aaduszki x fbugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+src/*.o
+bin/
+html/
+latex/
+lib/

--- a/src/InteractionData.cpp
+++ b/src/InteractionData.cpp
@@ -70,11 +70,19 @@ namespace NeutrinoFluxReweight{
     InteractionData::Inc_Mass  = particle->GetParticle(Inc_pdg)->Mass();
     InteractionData::Prod_Mass = particle->GetParticle(Prod_pdg)->Mass();
 
-
     //Ecm, gamma:
+    /**
+     * Center of mass of the system of projectile
+     * and nucleon (not the nucleus!)
+     */
+    static const double NUCLEON_MASS = 
+      (particle->GetParticle("proton")->Mass()
+      + particle->GetParticle("neutron")->Mass())/2;
+    static const double NUCLEON_MASS2 = NUCLEON_MASS * NUCLEON_MASS;
+
     double inc_E_lab = std::sqrt(Inc_P*Inc_P + pow(Inc_Mass,2));
-    InteractionData::Ecm       = std::sqrt(2.*pow(Inc_Mass,2)+2.*inc_E_lab*Inc_Mass); 
-    InteractionData::Betacm    = std::sqrt(pow(inc_E_lab,2)-pow(Inc_Mass,2.0))/(inc_E_lab + Inc_Mass); 
+    InteractionData::Ecm       = std::sqrt(pow(Inc_Mass,2) + NUCLEON_MASS2 + 2.*inc_E_lab*NUCLEON_MASS); 
+    InteractionData::Betacm    = std::sqrt(pow(inc_E_lab,2)-pow(Inc_Mass,2.0))/(inc_E_lab + NUCLEON_MASS); 
     InteractionData::Gammacm   = 1./std::sqrt(1.-pow(Betacm,2.0));
     
     //xF:


### PR DESCRIPTION
Fix a bug in calculation of xF: the original version used the incident particle mass as the target mass, which is incorrect; the target mass should be always the mass of a nucleon (n.b., not a nucleus). This makes a significant difference for interactions of light mesons, π and K.