### PR TITLE
Feature/bnayak negxfuboone

### DIFF
--- a/data/BINS/ThinTarget_MesonIncident.xml
+++ b/data/BINS/ThinTarget_MesonIncident.xml
@@ -5,25 +5,45 @@
     <ThinTarget_MesonIncident>
  
       <ThinTarget_MesonIncident_0>
-	<xfrange>0.00 0.25</xfrange>
+	<xfrange>-1.00 -0.75</xfrange>
 	<ptrange>0.00 2.00</ptrange>
       </ThinTarget_MesonIncident_0>      
 
       <ThinTarget_MesonIncident_1>
-	<xfrange>0.25 0.50</xfrange>
+	<xfrange>-0.75 -0.50</xfrange>
 	<ptrange>0.00 2.00</ptrange>
       </ThinTarget_MesonIncident_1>
 
       <ThinTarget_MesonIncident_2>
-	<xfrange>0.50 0.75</xfrange>
+	<xfrange>-0.50 -0.25</xfrange>
 	<ptrange>0.00 2.00</ptrange>
       </ThinTarget_MesonIncident_2>
 
       <ThinTarget_MesonIncident_3>
-	<xfrange>0.75 1.0</xfrange>
+	<xfrange>-0.25 0.00</xfrange>
 	<ptrange>0.00 2.00</ptrange>
       </ThinTarget_MesonIncident_3>
 
+      <ThinTarget_MesonIncident_4>
+	<xfrange>0.00 0.25</xfrange>
+	<ptrange>0.00 2.00</ptrange>
+      </ThinTarget_MesonIncident_4>      
+
+      <ThinTarget_MesonIncident_5>
+	<xfrange>0.25 0.50</xfrange>
+	<ptrange>0.00 2.00</ptrange>
+      </ThinTarget_MesonIncident_5>
+
+      <ThinTarget_MesonIncident_6>
+	<xfrange>0.50 0.75</xfrange>
+	<ptrange>0.00 2.00</ptrange>
+      </ThinTarget_MesonIncident_6>
+
+      <ThinTarget_MesonIncident_7>
+	<xfrange>0.75 1.00</xfrange>
+	<ptrange>0.00 2.00</ptrange>
+      </ThinTarget_MesonIncident_7>
+      
     </ThinTarget_MesonIncident>
  
 

--- a/src/ThinTargetMesonIncidentReweighter.cpp
+++ b/src/ThinTargetMesonIncidentReweighter.cpp
@@ -60,7 +60,7 @@ namespace NeutrinoFluxReweight{
     
     for(int ii=0;ii<5;ii++){
       for(int jj=0;jj<7;jj++){
-	for(int kk=0;kk<4;kk++){
+	for(int kk=0;kk<Thinbins->GetNbins_meson_incident();kk++){
 	  
 	  sprintf(namepar,"ThinTarget_%s_incident_%s_%d",cinc[ii],cpro[jj],kk);
 	  dataval = univPars.getParameterValue(std::string(namepar));
@@ -141,50 +141,54 @@ namespace NeutrinoFluxReweight{
     bool is_mesoninc = (aa.Inc_pdg >99 && aa.Inc_pdg < 1000) || (aa.Inc_pdg <-99 && aa.Inc_pdg > -1000);
     if(bin>=0 && right_inc && right_prod){
 
+      // same treatment as nucleon-A reweighter for xF < 0
+      double negxF_corrunc = 1.;
+      if(aa.xF < 0.) negxF_corrunc = bin_mesonleftover_inc;
+
       if(aa.Inc_pdg == 211){
-	if(aa.Prod_pdg == 211) wgt = vbin_pip_inc_pip[bin];
-	if(aa.Prod_pdg ==-211) wgt = vbin_pip_inc_pim[bin];
-	if(aa.Prod_pdg == 321) wgt = vbin_pip_inc_kap[bin];
-	if(aa.Prod_pdg ==-321) wgt = vbin_pip_inc_kam[bin];
-	if(aa.Prod_pdg ==130 || aa.Prod_pdg ==310) wgt = vbin_pip_inc_k0[bin];
-	if(aa.Prod_pdg ==2212) wgt = vbin_pip_inc_p[bin];
-	if(aa.Prod_pdg ==2112) wgt = vbin_pip_inc_n[bin];	
+	if(aa.Prod_pdg == 211) wgt = vbin_pip_inc_pip[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==-211) wgt = vbin_pip_inc_pim[bin] * negxF_corrunc;
+	if(aa.Prod_pdg == 321) wgt = vbin_pip_inc_kap[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==-321) wgt = vbin_pip_inc_kam[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==130 || aa.Prod_pdg ==310) wgt = vbin_pip_inc_k0[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==2212) wgt = vbin_pip_inc_p[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==2112) wgt = vbin_pip_inc_n[bin] * negxF_corrunc;	
       }
       else if(aa.Inc_pdg ==-211){
-	if(aa.Prod_pdg == 211) wgt = vbin_pim_inc_pip[bin];
-	if(aa.Prod_pdg ==-211) wgt = vbin_pim_inc_pim[bin];
-	if(aa.Prod_pdg == 321) wgt = vbin_pim_inc_kap[bin];
-	if(aa.Prod_pdg ==-321) wgt = vbin_pim_inc_kam[bin];
-	if(aa.Prod_pdg ==130 || aa.Prod_pdg ==310) wgt = vbin_pim_inc_k0[bin];
-	if(aa.Prod_pdg ==2212) wgt = vbin_pim_inc_p[bin];
-	if(aa.Prod_pdg ==2112) wgt = vbin_pim_inc_n[bin];	
+	if(aa.Prod_pdg == 211) wgt = vbin_pim_inc_pip[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==-211) wgt = vbin_pim_inc_pim[bin] * negxF_corrunc;
+	if(aa.Prod_pdg == 321) wgt = vbin_pim_inc_kap[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==-321) wgt = vbin_pim_inc_kam[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==130 || aa.Prod_pdg ==310) wgt = vbin_pim_inc_k0[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==2212) wgt = vbin_pim_inc_p[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==2112) wgt = vbin_pim_inc_n[bin] * negxF_corrunc;	
       }
       else if(aa.Inc_pdg == 321){
-	if(aa.Prod_pdg == 211) wgt = vbin_kap_inc_pip[bin];
-	if(aa.Prod_pdg ==-211) wgt = vbin_kap_inc_pim[bin];
-	if(aa.Prod_pdg == 321) wgt = vbin_kap_inc_kap[bin];
-	if(aa.Prod_pdg ==-321) wgt = vbin_kap_inc_kam[bin];
-	if(aa.Prod_pdg ==130 || aa.Prod_pdg ==310) wgt = vbin_kap_inc_k0[bin];
-	if(aa.Prod_pdg ==2212) wgt = vbin_kap_inc_p[bin];
-	if(aa.Prod_pdg ==2112) wgt = vbin_kap_inc_n[bin];	
+	if(aa.Prod_pdg == 211) wgt = vbin_kap_inc_pip[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==-211) wgt = vbin_kap_inc_pim[bin] * negxF_corrunc;
+	if(aa.Prod_pdg == 321) wgt = vbin_kap_inc_kap[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==-321) wgt = vbin_kap_inc_kam[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==130 || aa.Prod_pdg ==310) wgt = vbin_kap_inc_k0[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==2212) wgt = vbin_kap_inc_p[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==2112) wgt = vbin_kap_inc_n[bin] * negxF_corrunc;	
       }
       else if(aa.Inc_pdg ==-321){
-	if(aa.Prod_pdg == 211) wgt = vbin_kam_inc_pip[bin];
-	if(aa.Prod_pdg ==-211) wgt = vbin_kam_inc_pim[bin];
-	if(aa.Prod_pdg == 321) wgt = vbin_kam_inc_kap[bin];
-	if(aa.Prod_pdg ==-321) wgt = vbin_kam_inc_kam[bin];
-	if(aa.Prod_pdg ==130 || aa.Prod_pdg ==310) wgt = vbin_kam_inc_k0[bin];
-	if(aa.Prod_pdg ==2212) wgt = vbin_kam_inc_p[bin];
-	if(aa.Prod_pdg ==2112) wgt = vbin_kam_inc_n[bin];	
+	if(aa.Prod_pdg == 211) wgt = vbin_kam_inc_pip[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==-211) wgt = vbin_kam_inc_pim[bin] * negxF_corrunc;
+	if(aa.Prod_pdg == 321) wgt = vbin_kam_inc_kap[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==-321) wgt = vbin_kam_inc_kam[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==130 || aa.Prod_pdg ==310) wgt = vbin_kam_inc_k0[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==2212) wgt = vbin_kam_inc_p[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==2112) wgt = vbin_kam_inc_n[bin] * negxF_corrunc;	
       }
       else if(aa.Inc_pdg == 130 || aa.Inc_pdg == 310){
-	if(aa.Prod_pdg == 211) wgt = vbin_k0_inc_pip[bin];
-	if(aa.Prod_pdg ==-211) wgt = vbin_k0_inc_pim[bin];
-	if(aa.Prod_pdg == 321) wgt = vbin_k0_inc_kap[bin];
-	if(aa.Prod_pdg ==-321) wgt = vbin_k0_inc_kam[bin];
-	if(aa.Prod_pdg ==130 || aa.Prod_pdg ==310) wgt = vbin_k0_inc_k0[bin];
-	if(aa.Prod_pdg ==2212) wgt = vbin_k0_inc_p[bin];
-	if(aa.Prod_pdg ==2112) wgt = vbin_k0_inc_n[bin];	
+	if(aa.Prod_pdg == 211) wgt = vbin_k0_inc_pip[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==-211) wgt = vbin_k0_inc_pim[bin] * negxF_corrunc;
+	if(aa.Prod_pdg == 321) wgt = vbin_k0_inc_kap[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==-321) wgt = vbin_k0_inc_kam[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==130 || aa.Prod_pdg ==310) wgt = vbin_k0_inc_k0[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==2212) wgt = vbin_k0_inc_p[bin] * negxF_corrunc;
+	if(aa.Prod_pdg ==2112) wgt = vbin_k0_inc_n[bin] * negxF_corrunc;	
       }
       else{
 	std::cout<<"MESINC Something is wrong with pdg_inc: "<< aa.Inc_pdg  <<" "<<aa.Prod_pdg<<std::endl;
@@ -197,7 +201,8 @@ namespace NeutrinoFluxReweight{
     
     if(wgt<0){
       //std::cout<<"TTMESONINC check wgt(<0) "<<iUniv<<" "<<aa.Inc_P<<" "<<aa.xF<<" "<<aa.Pt<<" "<<aa.Prod_pdg<<std::endl;
-      return 1.0;
+      // same as nucleon-A, cap it to near-0 instead of returning 1.
+      return 0.0001;
     }
     if(wgt>10){
       std::cout<<"BIG WGT IN TTMESONINC "<<iUniv<<" "<<wgt<<" "<<aa.Inc_P<<" "<<aa.xF<<" "<<aa.Pt<<" "<<aa.Prod_pdg<<std::endl;

--- a/uncertainties/Parameters_default.xml
+++ b/uncertainties/Parameters_default.xml
@@ -112,38 +112,38 @@
 </MIPP_NuMI_kam_pim_sys>
 
 <ThinTarget_prt_incident_pip>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_prt_incident_pip>
 
 <ThinTarget_prt_incident_pim>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_prt_incident_pim>
 
 <ThinTarget_prt_incident_kap>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_prt_incident_kap>
 
 <ThinTarget_prt_incident_kam>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_prt_incident_kam>
 
 <ThinTarget_prt_incident_k0>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_prt_incident_k0>
 
 <ThinTarget_prt_incident_p>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_prt_incident_p>
 
 <ThinTarget_prt_incident_n>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_prt_incident_n>
 
 <ThinTarget_prtleftover_incident>
@@ -152,38 +152,38 @@
 </ThinTarget_prtleftover_incident>
 
 <ThinTarget_neu_incident_pip>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_neu_incident_pip>
 
 <ThinTarget_neu_incident_pim>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_neu_incident_pim>
 
 <ThinTarget_neu_incident_kap>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_neu_incident_kap>
 
 <ThinTarget_neu_incident_kam>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_neu_incident_kam>
 
 <ThinTarget_neu_incident_k0>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_neu_incident_k0>
 
 <ThinTarget_neu_incident_p>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_neu_incident_p>
 
 <ThinTarget_neu_incident_n>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_neu_incident_n>
 
 <ThinTarget_neuleftover_incident>
@@ -192,178 +192,178 @@
 </ThinTarget_neuleftover_incident>
 
 <ThinTarget_pip_incident_pip>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pip_incident_pip>
 
 <ThinTarget_pip_incident_pim>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pip_incident_pim>
 
 <ThinTarget_pip_incident_kap>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pip_incident_kap>
 
 <ThinTarget_pip_incident_kam>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pip_incident_kam>
 
 <ThinTarget_pip_incident_k0>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pip_incident_k0>
 
 <ThinTarget_pip_incident_p>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pip_incident_p>
 
 <ThinTarget_pip_incident_n>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pip_incident_n>
 
 <ThinTarget_pim_incident_pip>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pim_incident_pip>
 
 <ThinTarget_pim_incident_pim>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pim_incident_pim>
 
 <ThinTarget_pim_incident_kap>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pim_incident_kap>
 
 <ThinTarget_pim_incident_kam>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pim_incident_kam>
 
 <ThinTarget_pim_incident_k0>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pim_incident_k0>
 
 <ThinTarget_pim_incident_p>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pim_incident_p>
 
 <ThinTarget_pim_incident_n>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_pim_incident_n>
 
 <ThinTarget_kap_incident_pip>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kap_incident_pip>
 
 <ThinTarget_kap_incident_pim>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kap_incident_pim>
 
 <ThinTarget_kap_incident_kap>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kap_incident_kap>
 
 <ThinTarget_kap_incident_kam>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kap_incident_kam>
 
 <ThinTarget_kap_incident_k0>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kap_incident_k0>
 
 <ThinTarget_kap_incident_p>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kap_incident_p>
 
 <ThinTarget_kap_incident_n>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kap_incident_n>
 
 <ThinTarget_kam_incident_pip>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kam_incident_pip>
 
 <ThinTarget_kam_incident_pim>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kam_incident_pim>
 
 <ThinTarget_kam_incident_kap>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kam_incident_kap>
 
 <ThinTarget_kam_incident_kam>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kam_incident_kam>
 
 <ThinTarget_kam_incident_k0>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kam_incident_k0>
 
 <ThinTarget_kam_incident_p>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kam_incident_p>
 
 <ThinTarget_kam_incident_n>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_kam_incident_n>
 
 <ThinTarget_k0_incident_pip>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_k0_incident_pip>
 
 <ThinTarget_k0_incident_pim>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_k0_incident_pim>
 
 <ThinTarget_k0_incident_kap>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_k0_incident_kap>
 
 <ThinTarget_k0_incident_kam>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_k0_incident_kam>
 
 <ThinTarget_k0_incident_k0>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_k0_incident_k0>
 
 <ThinTarget_k0_incident_p>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_k0_incident_p>
 
 <ThinTarget_k0_incident_n>
-<cvs>1.0 1.0 1.0 1.0</cvs>
-<errs>0.4 0.4 0.4 0.4</errs>
+<cvs>1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</cvs>
+<errs>0.4 0.4 0.4 0.4 0.4 0.4 0.4 0.4</errs>
 </ThinTarget_k0_incident_n>
 
 <ThinTarget_mesonleftover_incident>


### PR DESCRIPTION
The main issues this PR addresses is : 

- nucleon-A events with xF < 0 getting 0% uncertainty in PPFX
- homogenising treatment for MesonInc and nucleon-A events for xF < 0
- Hard-coded number of bins in the MesonInc reweighter

It does this by extending the number of bins for the MesonIncident reweighter to 8 in total, going from (-1, 1) instead of (0, 1) before and applying a correlated 40% + uncorrelated 40% across the negative xF bins. 

This is the current implementation of PPFX in MicroBooNE with the extra addition of the changes in this [PR](https://github.com/kordosky/ppfx/pull/1). This should have a sizeable impact on very off-axis NuMI experiments but negligible for on-axis/nearly on-axis NuMI experiments.

More details are given in the talk to the PPFX WG [here](https://indico.fnal.gov/event/60208/contributions/269106/attachments/168112/225052/6_19_23_ppfx.pdf)