### PR TITLE
deal with unused variables found by gcc 12

### DIFF
--- a/src/CentralValuesAndUncertainties.cpp
+++ b/src/CentralValuesAndUncertainties.cpp
@@ -151,7 +151,7 @@ namespace NeutrinoFluxReweight{
     double sigma_pc_kam = r3->Gaus(0.0,1.0);
     double sigma_pc_p   = r3->Gaus(0.0,1.0);
     double sigma_pc_n   = r3->Gaus(0.0,1.0);
-    double sigma_pipC_pip = r3_pip->Gaus(0.0, 1.0);   
+    // double sigma_pipC_pip = r3_pip->Gaus(0.0, 1.0);   // unused
     const boost::interprocess::flat_map<std::string, double>& table_uncorr_pars = uncorrelated_pars.getMap();
     boost::interprocess::flat_map<std::string, double>::const_iterator it = table_uncorr_pars.begin();
 

--- a/src/FillIMapHists.cpp
+++ b/src/FillIMapHists.cpp
@@ -140,9 +140,9 @@ double FillOneEntry(bsim::Dk2Nu* dk2nu, bsim::DkMeta* dkmeta, HistList* hists, c
     //if(opts->cut_mipp && numi_pion_nodes[iinter]) continue;                        //BHUMIKA, commented as these two are for mipp 
     //if(opts->cut_mipp && numi_kaon_nodes[iinter]) continue;
     // Thin target reweighters are based on data and theoretical motivated data extensions.
-    bool covered_by_na61 = false;
+    // bool covered_by_na61 = false; // unused
     if(reweighters->ThinTargetpipCpip->canReweight(interdata)){
-       covered_by_na61 = true;
+       // covered_by_na61 = true; // unused
        if(! opts->cut_na61) hists->_h_aveint_vs_enu_pipCpip->Fill(enu,weight);
                      }
      

--- a/src/ThinTargetMC.cpp
+++ b/src/ThinTargetMC.cpp
@@ -88,7 +88,7 @@ namespace NeutrinoFluxReweight{
     if(pdgcode!=211 && pdgcode!=-211 && pdgcode!=321 && pdgcode!=-321 && pdgcode!=2212 && pdgcode!=2112 && pdgcode!=130 && pdgcode!=310)return -1;    
     //idx:
     int idx_part = -1;
-    int idx_qe_corr = -1;
+    //int idx_qe_corr = -1; // unused
     int idx_lowp = -1;
     int idx_hip  = -1;
     for(size_t i=0;i<mom_inc.size()-1;i++){
@@ -107,38 +107,39 @@ namespace NeutrinoFluxReweight{
     if(pdgcode == -321)idx_part=3;
     if(pdgcode == 2212){
       idx_part    = 4;
-      idx_qe_corr = 0;
+      //idx_qe_corr = 0; // unused
     }
     if(pdgcode == 2112){
        idx_part    = 7;
-       idx_qe_corr = 1;
+       //idx_qe_corr = 1; // unused
     }
     if(pdgcode ==  130)idx_part=5;
     if(pdgcode ==  310)idx_part=6;
     
     double mcval    = 0.0;
-    double qe_corr = 1.0;
+    // some of this code exists to set qe_corr, which is not used
+    //double qe_corr = 1.0;
     if(idx_part<7){
       int binp     = vpC_x[idx_part][idx_lowp]->FindBin(xf,pt);
       double mclow = vpC_x[idx_part][idx_lowp]->GetBinContent(binp);
       double mchi  = vpC_x[idx_part][idx_hip]->GetBinContent(binp);
       mcval = mclow + (incP-double(mom_inc[idx_lowp]))*(mchi-mclow)/(double(mom_inc[idx_hip])-double(mom_inc[idx_lowp]));
-      if(idx_qe_corr==0){
-	int binqe       = vqe_corr_p[idx_lowp]->FindBin(xf,pt);
-	double qelow    = vqe_corr_p[idx_lowp]->GetBinContent(binqe);
-	double qehi     = vqe_corr_p[idx_hip]->GetBinContent(binqe);
-	 qe_corr  = qelow + (incP-double(mom_inc[idx_lowp]))*(qehi-qelow)/(double(mom_inc[idx_hip])-double(mom_inc[idx_lowp]));
-      }
+      //if(idx_qe_corr==0){
+	//int binqe       = vqe_corr_p[idx_lowp]->FindBin(xf,pt);
+	//double qelow    = vqe_corr_p[idx_lowp]->GetBinContent(binqe);
+	//double qehi     = vqe_corr_p[idx_hip]->GetBinContent(binqe);
+	 //qe_corr  = qelow + (incP-double(mom_inc[idx_lowp]))*(qehi-qelow)/(double(mom_inc[idx_hip])-double(mom_inc[idx_lowp]));
+      //}
     }
     else if(idx_part==7){
       int binp     = vpC_n[idx_lowp]->FindBin(xf);
       double mclow = vpC_n[idx_lowp]->GetBinContent(binp);
       double mchi  = vpC_n[idx_hip]->GetBinContent(binp);
       mcval = mclow + (incP-double(mom_inc[idx_lowp]))*(mchi-mclow)/(double(mom_inc[idx_hip])-double(mom_inc[idx_lowp]));
-      int binqe    = vqe_corr_n[idx_lowp]->FindBin(xf);
-      double qelow = vqe_corr_n[idx_lowp]->GetBinContent(binqe);
-      double qehi  = vqe_corr_n[idx_hip]->GetBinContent(binqe);
-      qe_corr  = qelow + (incP-double(mom_inc[idx_lowp]))*(qehi-qelow)/(double(mom_inc[idx_hip])-double(mom_inc[idx_lowp]));
+      //int binqe    = vqe_corr_n[idx_lowp]->FindBin(xf);
+      //double qelow = vqe_corr_n[idx_lowp]->GetBinContent(binqe);
+      //double qehi  = vqe_corr_n[idx_hip]->GetBinContent(binqe);
+      //qe_corr  = qelow + (incP-double(mom_inc[idx_lowp]))*(qehi-qelow)/(double(mom_inc[idx_hip])-double(mom_inc[idx_lowp]));
     }
     
 //    mcval /=qe_corr;

--- a/src/ThinTargetpipCReweighter.cpp
+++ b/src/ThinTargetpipCReweighter.cpp
@@ -6,7 +6,8 @@ namespace NeutrinoFluxReweight{
   
   ThinTargetpipCReweighter::ThinTargetpipCReweighter(int iuniv, const ParameterTable& cv_pars, const ParameterTable& univ_pars):iUniv(iuniv),cvPars(cv_pars),univPars(univ_pars){
     
-    ThinTargetBins* Thinbins =  ThinTargetBins::getInstance();
+    // not doing anything with Thinbins
+    //ThinTargetBins* Thinbins =  ThinTargetBins::getInstance();
     
     
     //1 incident particles, 8 produced particles:

--- a/src/ThinTargetpipCpipBins.cpp
+++ b/src/ThinTargetpipCpipBins.cpp
@@ -238,7 +238,7 @@ namespace NeutrinoFluxReweight{
   int ThinTargetpipCpipBins::pipC_pip_BinID(double Prod_P,double Theta, int Inc_pdg, int Prod_pdg){
     
     int ibinID = -1;
-    int size = 0;
+    //int size = 0; // unused
     bool israngea = (Prod_pdg == 211 && Inc_pdg == 211) ;
       if (israngea){
       for(int ii=0;ii<200;++ii){
@@ -255,7 +255,7 @@ return ibinID;
  int ThinTargetpipCpipBins::pipC_pim_BinID(double Prod_P,double Theta, int Inc_pdg, int Prod_pdg){
 
     int ibinID = -1;
-    int size = 0;
+    //int size = 0; // unused
     bool israngea = (Prod_pdg == -211 && Inc_pdg == 211) ;
       if (israngea){
       for(int ii=0;ii<200;++ii){
@@ -272,7 +272,7 @@ return ibinID;
  int ThinTargetpipCpipBins::pipC_kp_BinID(double Prod_P,double Theta, int Inc_pdg, int Prod_pdg){
 
     int ibinID = -1;
-    int size = 0;
+    //int size = 0; // unused
 
   
     bool israngea = (Prod_pdg == 321 && Inc_pdg == 211) ;
@@ -291,7 +291,7 @@ return ibinID;
  int ThinTargetpipCpipBins::pipC_km_BinID(double Prod_P,double Theta, int Inc_pdg, int Prod_pdg){
 
     int ibinID = -1;
-    int size = 0;
+    //int size = 0; // unused
 
    
     bool israngea = (Prod_pdg == -321 && Inc_pdg == 211) ;
@@ -310,7 +310,7 @@ return ibinID;
    int ThinTargetpipCpipBins::pipC_p_BinID(double Prod_P,double Theta, int Inc_pdg, int Prod_pdg){
 
     int ibinID = -1;
-    int size = 0;
+    //int size = 0; // unused
 
    
     bool israngea = (Prod_pdg == 2212 && Inc_pdg == 211) ;
@@ -330,7 +330,7 @@ return ibinID;
  int ThinTargetpipCpipBins::pipC_k0s_BinID(double Prod_P,double Theta, int Inc_pdg, int Prod_pdg){
 
     int ibinID = -1;
-    int size = 0;
+    //int size = 0; // unused
 
     bool israngea = (Prod_pdg == 310 && Inc_pdg == 211) ;
       if (israngea){
@@ -348,7 +348,7 @@ return ibinID;
  int ThinTargetpipCpipBins::pipC_lam_BinID(double Prod_P,double Theta, int Inc_pdg, int Prod_pdg){
 
     int ibinID = -1;
-    int size = 0;
+    //int size = 0; // unused
 
   
     bool israngea = (Prod_pdg == 3122 && Inc_pdg == 211) ;
@@ -367,7 +367,7 @@ return ibinID;
  int ThinTargetpipCpipBins::pipC_alam_BinID(double Prod_P,double Theta, int Inc_pdg, int Prod_pdg){
 
     int ibinID = -1;
-    int size = 0;
+    //int size = 0; // unused
     bool israngea = (Prod_pdg == -3122 && Inc_pdg == 211) ;
       if (israngea){
       for(int ii=0;ii<11;++ii){

--- a/src/ThinTargetpipCpipReweighter.cpp
+++ b/src/ThinTargetpipCpipReweighter.cpp
@@ -135,7 +135,7 @@ namespace NeutrinoFluxReweight{
     else return false;
 
   bool can_reweight = false;
- int bin = -1; 
+ //int bin = -1; // this "bin" is not used
  ThinTargetpipCpipBins*  Thinbins =  ThinTargetpipCpipBins::getInstance();
 if(aa.Prod_pdg == 211) {
       int bin = Thinbins->pipC_pip_BinID(aa.Prod_P,aa.Theta,aa.Inc_pdg,aa.Prod_pdg);
@@ -179,7 +179,7 @@ return can_reweight;
     double wgt = 1.0;
     double low_value = 1.e-18;     
     int bin = -1;
-    bool right_inc = aa.Inc_pdg == 211;
+    //bool right_inc = aa.Inc_pdg == 211; // right_inc not used
    if(aa.Inc_pdg != 211){std::cout<<"Can reweight is not working properly, setting wgt 1"<<std::endl;
    return wgt; } 
 

--- a/src/doReweight_dk2nu_originalpip.C
+++ b/src/doReweight_dk2nu_originalpip.C
@@ -40,7 +40,7 @@ std::string change_to_xrootd_path(std::string temp);
  */
 void doReweight_dk2nu(const char* inputFile, const char* outputFile, const char* optionsFile, const char* cxxdet, const char* cyydet, const char* czzdet){ 
   
-  const char* thisDir = getenv("PPFX_DIR");
+  //const char* thisDir = getenv("PPFX_DIR"); // unused
   int idet = -1;    //this is identity of the detector
   bool doing_precalculated_pos = false;  //Initially we are assuming that there is no precalculated position of the detector
   
@@ -286,9 +286,9 @@ void doReweight_dk2nu(const char* inputFile, const char* outputFile, const char*
     for(int jj=0;jj<Nuniverses;jj++){
       double wgt_thin = vwgt_ttpCpi[jj]*vwgt_ttpCk[jj]*vwgt_ttnCpi[jj]*vwgt_ttpCnu[jj]*vwgt_ttnua[jj];
      // double wgt_mipp = vwgt_mipp_pi[jj]*vwgt_mipp_K[jj];
-      double wgt_na61 = vwgt_ttpipinc[jj]; 
+      //double wgt_na61 = vwgt_ttpipinc[jj]; //unused
       double wgt_att = vwgt_att[jj]*vwgt_abs[jj];
-      double wgt_mes = vwgt_ttmesinc[jj];   
+      //double wgt_mes = vwgt_ttmesinc[jj];   // unused
    
       hthin[nuidx][jj]->Fill(nuenergy,fluxWGT*wgt_thin);
       hmesinc[nuidx][jj]->Fill(nuenergy,fluxWGT*vwgt_ttmesinc[jj]);

--- a/src/make_basic_fluxhistograms.C
+++ b/src/make_basic_fluxhistograms.C
@@ -41,7 +41,7 @@ std::string change_to_xrootd_path(std::string temp);
 
 void make_basic_fluxhistograms(const char* inputFile, const char* outputFile, const char* cdet){ 
   
-  const char* thisDir = getenv("PPFX_DIR");
+  //const char* thisDir = getenv("PPFX_DIR"); // unused
   int idet = atoi(cdet);
   
   std::cout<<"Making an output file to store histograms"<<std::endl;
@@ -104,7 +104,7 @@ void make_basic_fluxhistograms(const char* inputFile, const char* outputFile, co
     hflux[nuidx]->Fill(enu,flxwgt);
     
     InteractionChainData ichaindata(dk2nu,dkmeta);
-    unsigned int nanc = (ichaindata.interaction_chain).size();
+    //unsigned int nanc = (ichaindata.interaction_chain).size(); // unused
     InteractionData idata = (ichaindata.interaction_chain)[0];
     double xF  = idata.xF;
     double Pt  = idata.Pt;

--- a/src/minos2nova.C
+++ b/src/minos2nova.C
@@ -144,11 +144,12 @@ void minos2nova(const char* inputFiles, const char* outputFile, const char* opti
     }//end of det
   }//end of hel
 
+// array bounds are ‘TH2D* [2]’ - presume that htrans[i][0] and htrans[i][1] are intended
   std::cout<<"storing general histos"<<std::endl;
   fOut->cd();
   for(int i=0;i<Nhel;i++){
+    htrans[i][0]->Write();
     htrans[i][1]->Write();
-    htrans[i][2]->Write();
     fOut->mkdir(Form("h%s",hel[i]));
     fOut->cd(Form("h%s",hel[i]));
     for(int j=0;j<Ndet;j++){

--- a/src/trial_ivol.C
+++ b/src/trial_ivol.C
@@ -18,7 +18,7 @@ void trial_ivol(const char* inputFile,const char* outputFile){
 
 //start with the reweighter...not sure if we need it or not
 
-  MakeReweight* makerew = MakeReweight::getInstance();
+  //MakeReweight* makerew = MakeReweight::getInstance(); // unused
   
   TChain* chain_evts   = new TChain("dk2nuTree");  
   TChain* chain_meta   = new TChain("dkmetaTree");  
@@ -41,20 +41,20 @@ void trial_ivol(const char* inputFile,const char* outputFile){
   ifs.close();  
 
   chain_evts->SetBranchAddress("dk2nu",&dk2nu);
-  int nentries  = chain_evts->GetEntries();
+  //int nentries  = chain_evts->GetEntries(); // unused
 
   chain_meta->SetBranchAddress("dkmeta",&dkmeta);
   chain_meta->GetEntry(0); //all entries are the same    
   
-  int ntot = chain_evts->GetEntries();
+  //int ntot = chain_evts->GetEntries(); // unused
   
   for(int i =0;i<1000;i++){
    chain_evts->GetEntry(i);
    NeutrinoFluxReweight::InteractionChainData icd(dk2nu,dkmeta);  
   
-   const int ninter = icd.interaction_chain.size();
+   //const int ninter = icd.interaction_chain.size(); // unused
    
-   const int ptv_size = icd.ptv_info.size();
+   //const int ptv_size = icd.ptv_info.size(); // unused
    
    //std::cout<<"intersize "<<ninter<<" ptv size "<<ptv_size<<std::endl;
   


### PR DESCRIPTION
When compiling with a newer gcc (gcc 12), a number of unused variables are found.  This pull request simply comments out the unused code.  Code authors, please review.

Also, there is a probable bug in src/minos2nova.C